### PR TITLE
fix: updateSimpleField method to allow validations

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -237,7 +237,8 @@ class ModelClass implements Model, ChangeItem {
       fieldArgs.validations = extractFieldValidations(fieldArgs);
     }
 
-    const field = new Field(fieldArgs, MutationMode.Update);
+    const { type, ...fieldChanges } = fieldArgs;
+    const field = new Field(fieldChanges, MutationMode.Update);
     this.listener.registerChange(field);
     return this;
   }


### PR DESCRIPTION
Allow a user to update the validations on a simple field by destructuring the type once the validation has been formatted.

In order to successfully perform an update to a fields validations, you will have to pass a type e.g `type: FieldType.String` so that we can extract and format the correct validations field. However once this is done you no longer need it. Therefore we destructure the type node, and pass the relevant changes to the mutation.

```
const model = migration.model('example');

model.updateSimpleField({
  apiId: 'test',
  type: FieldType.String,
  validations: {
     matches: {...}
 }
});
```