### PR TITLE
fix: prevent mutating passed field args

### DIFF
--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -507,6 +507,7 @@ export enum GraphQLPermissionAction {
   ContentviewCreate = "CONTENTVIEW_CREATE",
   ContentviewRead = "CONTENTVIEW_READ",
   ContentviewUpdate = "CONTENTVIEW_UPDATE",
+  ContentviewSystemUpdate = "CONTENTVIEW_SYSTEM_UPDATE",
   ContentviewDelete = "CONTENTVIEW_DELETE",
   /** Project Storage Buckets */
   StorageBucketCreate = "STORAGE_BUCKET_CREATE",
@@ -667,6 +668,7 @@ export enum GraphQLAuditLogAction {
   Delete = "DELETE",
   Publish = "PUBLISH",
   Unpublish = "UNPUBLISH",
+  Accept = "ACCEPT",
 }
 
 export enum GraphQLAuditLogTriggerType {
@@ -688,7 +690,7 @@ export type GraphQLAuditLog = {
   resource: GraphQLAuditLogResource;
   action: GraphQLAuditLogAction;
   environmentName?: Maybe<Scalars["String"]>;
-  payload: Scalars["JSON"];
+  payload?: Maybe<Scalars["JSON"]>;
   triggeredBy?: Maybe<GraphQLAuditLogTriggeredBy>;
   triggerType: GraphQLAuditLogTriggerType;
 };
@@ -1509,6 +1511,7 @@ export type GraphQLEnvironment = {
   integration: GraphQLIIntegration;
   extensions: Array<GraphQLIExtension>;
   extension: GraphQLIExtension;
+  diff: GraphQLDiffEnvironmentPayload;
 };
 
 export type GraphQLEnvironmentWebhookArgs = {
@@ -1534,6 +1537,10 @@ export type GraphQLEnvironmentIntegrationArgs = {
 
 export type GraphQLEnvironmentExtensionArgs = {
   id: Scalars["ID"];
+};
+
+export type GraphQLEnvironmentDiffArgs = {
+  environmentId: Scalars["ID"];
 };
 
 export type GraphQLPublicContentApiDefauts = {
@@ -2421,6 +2428,13 @@ export type GraphQLFieldValidationRegEx = {
   __typename?: "FieldValidationRegEx";
   regex?: Maybe<Scalars["String"]>;
   flags?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  errorMessage?: Maybe<Scalars["String"]>;
+};
+
+export type GraphQLFieldValidationIntRange = {
+  __typename?: "FieldValidationIntRange";
+  min?: Maybe<Scalars["Int"]>;
+  max?: Maybe<Scalars["Int"]>;
   errorMessage?: Maybe<Scalars["String"]>;
 };
 
@@ -3368,7 +3382,7 @@ export type GraphQLDeleteLocaleInput = {
   /** ID of Locale to delete */
   id: Scalars["ID"];
   /**
-   * Delete all localizations for this loclae.
+   * Delete all localizations for this locale.
    * This will prevent an exception from
    * being raised if documents were previously
    * localized in this locale
@@ -3514,6 +3528,7 @@ export type GraphQLBatchMigrationCreateModelInput = {
   apiIdPlural: Scalars["String"];
   displayName: Scalars["String"];
   description?: Maybe<Scalars["String"]>;
+  previewURLs?: Maybe<Array<GraphQLPreviewUrlInput>>;
 };
 
 /** Creating a remote type definition */
@@ -3575,6 +3590,7 @@ export type GraphQLBatchMigrationUpdateModelInput = {
   apiIdPlural?: Maybe<Scalars["String"]>;
   displayName?: Maybe<Scalars["String"]>;
   description?: Maybe<Scalars["String"]>;
+  previewURLs?: Maybe<Array<GraphQLPreviewUrlInput>>;
 };
 
 /** Deleting a field. */
@@ -3897,6 +3913,40 @@ export type GraphQLBatchMigrationChangeInput = {
   createLocale?: Maybe<GraphQLBatchMigrationCreateLocaleInput>;
   deleteLocale?: Maybe<GraphQLBatchMigrationDeleteLocaleInput>;
   updateLocale?: Maybe<GraphQLBatchMigrationUpdateLocaleInput>;
+};
+
+export type GraphQLBatchMigrationChange = {
+  __typename?: "BatchMigrationChange";
+  /** Models */
+  createModel?: Maybe<Scalars["JSON"]>;
+  updateModel?: Maybe<Scalars["JSON"]>;
+  deleteModel?: Maybe<Scalars["JSON"]>;
+  /** Fields */
+  createSimpleField?: Maybe<Scalars["JSON"]>;
+  updateSimpleField?: Maybe<Scalars["JSON"]>;
+  createRelationalField?: Maybe<Scalars["JSON"]>;
+  updateRelationalField?: Maybe<Scalars["JSON"]>;
+  deleteField?: Maybe<Scalars["JSON"]>;
+  /** Locale */
+  createLocale?: Maybe<Scalars["JSON"]>;
+  deleteLocale?: Maybe<Scalars["JSON"]>;
+  updateLocale?: Maybe<Scalars["JSON"]>;
+};
+
+export type GraphQLExportEnvironmentInput = {
+  environmentId: Scalars["ID"];
+};
+
+export type GraphQLExportEnvironmentPayload = {
+  __typename?: "ExportEnvironmentPayload";
+  changes: Array<GraphQLBatchMigrationChange>;
+};
+
+export type GraphQLDiffEnvironmentPayload = {
+  __typename?: "DiffEnvironmentPayload";
+  environmentId: Scalars["ID"];
+  name?: Maybe<Scalars["String"]>;
+  changes: Array<GraphQLBatchMigrationChange>;
 };
 
 export type GraphQLBatchMigrationInput = {
@@ -4244,6 +4294,7 @@ export type GraphQLMutation = {
   updateUnionField: GraphQLAsyncOperationPayload;
   deleteField: GraphQLAsyncOperationPayload;
   submitBatchChanges: GraphQLAsyncOperationPayload;
+  exportEnvironment: GraphQLExportEnvironmentPayload;
   enableScheduledPublishing: GraphQLProject;
 };
 
@@ -4629,6 +4680,10 @@ export type GraphQLMutationDeleteFieldArgs = {
 
 export type GraphQLMutationSubmitBatchChangesArgs = {
   data: GraphQLBatchMigrationInput;
+};
+
+export type GraphQLMutationExportEnvironmentArgs = {
+  data: GraphQLExportEnvironmentInput;
 };
 
 export type GraphQLMutationEnableScheduledPublishingArgs = {

--- a/src/model.ts
+++ b/src/model.ts
@@ -188,7 +188,8 @@ class ModelClass implements Model, ChangeItem {
     private args: ModelArgs
   ) {}
 
-  addSimpleField(fieldArgs: any): Model {
+  addSimpleField(passedFieldArgs: any): Model {
+    const fieldArgs = { ...passedFieldArgs };
     fieldArgs.modelApiId = this.args.apiId;
     if (fieldArgs.type === GraphQLSimpleFieldType.String) {
       fieldArgs.formRenderer = fieldArgs.formRenderer || Renderer.SingleLine;
@@ -203,7 +204,8 @@ class ModelClass implements Model, ChangeItem {
     return this;
   }
 
-  addRemoteField(fieldArgs: any): Model {
+  addRemoteField(passedFieldArgs: any): Model {
+    const fieldArgs = { ...passedFieldArgs };
     fieldArgs.modelApiId = this.args.apiId;
     fieldArgs.type = GraphQLRemoteFieldType.Remote;
     if (fieldArgs.remoteConfig.headers) {
@@ -230,7 +232,8 @@ class ModelClass implements Model, ChangeItem {
     return this;
   }
 
-  updateSimpleField(fieldArgs: any): Model {
+  updateSimpleField(passedFieldArgs: any): Model {
+    const fieldArgs = { ...passedFieldArgs };
     fieldArgs.modelApiId = this.args.apiId;
 
     if (fieldArgs.validations) {
@@ -243,7 +246,8 @@ class ModelClass implements Model, ChangeItem {
     return this;
   }
 
-  addRelationalField(fieldArgs: any): Model {
+  addRelationalField(passedFieldArgs: any): Model {
+    const fieldArgs = { ...passedFieldArgs };
     fieldArgs.modelApiId = this.args.apiId;
     if (
       (fieldArgs.type && fieldArgs.type === "ASSET") ||
@@ -296,7 +300,8 @@ class ModelClass implements Model, ChangeItem {
     return this;
   }
 
-  addUnionField(fieldArgs: any): Model {
+  addUnionField(passedFieldArgs: any): Model {
+    const fieldArgs = { ...passedFieldArgs };
     fieldArgs.modelApiId = this.args.apiId;
     if (!fieldArgs.models || fieldArgs.models.length === 0) {
       throw new Error(`models cannot be empty`);
@@ -330,7 +335,8 @@ class ModelClass implements Model, ChangeItem {
     return this;
   }
 
-  updateRelationalField(fieldArgs: any): Model {
+  updateRelationalField(passedFieldArgs: any): Model {
+    const fieldArgs = { ...passedFieldArgs };
     fieldArgs.modelApiId = this.args.apiId;
 
     const field = new Field(
@@ -342,7 +348,8 @@ class ModelClass implements Model, ChangeItem {
     return this;
   }
 
-  updateUnionField(fieldArgs: any): Model {
+  updateUnionField(passedFieldArgs: any): Model {
+    const fieldArgs = { ...passedFieldArgs };
     fieldArgs.modelApiId = this.args.apiId;
     fieldArgs.reverseField = {
       modelApiIds: fieldArgs.models,
@@ -361,7 +368,8 @@ class ModelClass implements Model, ChangeItem {
     return this;
   }
 
-  addEnumerableField(fieldArgs: any): Model {
+  addEnumerableField(passedFieldArgs: any): Model {
+    const fieldArgs = { ...passedFieldArgs };
     if (!fieldArgs.enumerationApiId) {
       throw new Error("enumerationApiId is required for enumerable field");
     }
@@ -375,7 +383,8 @@ class ModelClass implements Model, ChangeItem {
     return this;
   }
 
-  updateEnumerableField(fieldArgs: any): Model {
+  updateEnumerableField(passedFieldArgs: any): Model {
+    const fieldArgs = { ...passedFieldArgs };
     fieldArgs.modelApiId = this.args.apiId;
 
     const field = new Field(


### PR DESCRIPTION
I was writing code to reuse some common field definitions across models like so

```ts
const nameField = {
    apiId: 'name',
    displayName: 'Name',
    type: FieldType.String,
    isRequired: true,
};

migration
    .createModel({ apiId: 'Ingredient', apiIdPlural: 'Ingredients', displayName: 'Ingredient' })
    .addSimpleField(nameField)

migration
    .createModel({ apiId: 'Drink', apiIdPlural: 'Drinks', displayName: 'Drink' })
    .addSimpleField(nameField)
```

and getting errors stating `Could not find model with apiId: Drink` it turns out that the `fieldArgs` that are passed by reference by JS to the `addSimpleField` function where mutated by the function so by the time the migration ran the `addSimpleField` args for the Ingredient model where having a `modelApiId: 'Drink'` property set. 

This PR removes the side effect of mutating the arguments to the functions.